### PR TITLE
Implemented centralised logging.

### DIFF
--- a/GAVPI/GAVPI/Logging.cs
+++ b/GAVPI/GAVPI/Logging.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrivialLogging
+{
+
+
+
+    //
+    //  class Logging< T >
+    //
+    //  A trivial, thread-safe generic logging class with callback functionality, Logging implements blanket
+    //  object locking to ensure only one thread may manipulate or query a simple queue of log entries at a
+    //  time.
+    //
+    //  USAGE:
+    //
+    //    using TrivialLogging;
+    //
+    //    ...
+    //
+    //    try {
+    //
+    //      Logging< string > log = new Logging< string >( MyCallback );
+    //
+    //    catch( Exception e ) { ... }
+    //
+    //    log.Entry( "Hello world!" );
+    //
+    //    ...
+    //
+    //    public void MyCallback( string LoggedEntry )
+    //    {
+    //
+    //       Console.Writeln( LoggedEntry );
+    //
+    //    }
+    //
+    //  OUTPUT:
+    //
+    //    Hello World!
+    //    
+
+    class Logging< T >
+    {
+
+        //  Our log, a FIFO queue:
+
+        private Queue< T > Log;
+    
+        //  We support callbacks (optionally passed to the constructor), and we'll define and acknowledge it
+        //  here.
+
+        public delegate void Callback( T loggedEntry );
+
+        private Callback OnLoggedMessageCallback;
+
+
+
+        //
+        //  public Logging()
+        //
+        //  The default constructor will re-throw any exceptions thrown while attempting to instantiate the
+        //  queue.
+        //
+
+        public Logging()
+        { 
+        
+            try {
+
+                Log = new Queue< T >();
+
+            } catch ( Exception e ) { throw; }
+           
+        }  //  public Logging()
+
+
+
+        //
+        //  public Logging( Callback )
+        //
+        //  A constructor taking a callback function.  The callback function must accept the same type, T,
+        //  as the class as its only argument.
+        //
+
+        public Logging( Callback callbackFunction ) : this()
+        {
+
+            if( callbackFunction != null ) OnLoggedMessageCallback = callbackFunction;
+
+        }  //  Logging( Callback )
+
+
+
+        //
+        //  public void Entry( T )
+        //
+        //  Add an entry of expected type T to the log queue, calling an optional callback function upon
+        //  completion.
+        //
+
+        public void Entry( T logEntry )
+        {
+
+            lock( Log ) {
+
+                Log.Enqueue( logEntry );
+               
+                if( OnLoggedMessageCallback != null ) OnLoggedMessageCallback( logEntry );
+
+            }  //  lock()
+
+        }  //  public void Entry( T )
+        
+        
+
+        //
+        //  public array ToArray()
+        //
+        //  Return an Array object consisting of the logged Entries.
+        //
+
+        public Array ToArray()
+        {
+
+            lock( Log ) { 
+
+                return Log.ToArray();
+
+            }
+            
+        }  //  public Array ToArray()
+    
+
+
+        //
+        //  public int Count()
+        //
+        //  Return the number of entries, zero-based, in the log queue.
+        //
+
+        public int Count()
+        {
+
+            lock( Log ) { 
+
+                return Log.Count;
+
+            }
+        
+        }  //  public int Count()
+
+
+
+        //
+        //  public void Clear()
+        //
+        //  Clear the log.  This method is destructive, so you may wish to persist the log by way of a call to
+        //  ToArray() first.
+        //
+                
+        public void Clear()
+        {
+
+            lock( Log ) { 
+
+                Log.Clear();
+
+            }
+
+        }  //  public void Clear()
+      
+    }  //  class Logging< T >
+
+}  //  namespage TrivialLogging

--- a/GAVPI/GAVPI/VI.cs
+++ b/GAVPI/GAVPI/VI.cs
@@ -20,7 +20,7 @@ namespace GAVPI
     {
         SpeechSynthesizer vi_syn;
         SpeechRecognitionEngine vi_sre;
-        ListView statusContainer; // listview in main form
+        
         private bool pushtotalk_active;
         private bool pushtotalk_keyIsDown;
         private KeyboardHook.KeyDownEventHandler pushtotalk_keyDownHook;
@@ -46,10 +46,8 @@ namespace GAVPI
 		//  success.
 		//
 		
-        public bool load_listen( ListView statusContainer )
+        public bool load_listen()
         {
-
-            this.statusContainer = statusContainer;
 
             vi_syn = GAVPI.vi_profile.synth;
             vi_syn.SelectVoice( GAVPI.vi_settings.voice_info );
@@ -221,25 +219,19 @@ namespace GAVPI
             }
         }
 
+
+
         //
         //  private void UpdateStatusLog( string )
         //
-        //  The main Form contains a ListView control maintains a running log of all recognised commands and keystrokes,
+        //  The main Form contains a ListBox showing a running log of all recognised commands and keystrokes,
         //  updated with a log message at each entry.
         //
 
         private void UpdateStatusLog( string LogMessage )
         {
 
-            //  Add the passed message to the running log...
-
-            statusContainer.Items.Add( LogMessage );
-
-            //  ... And always ensure that the last entry added to the statusContainer list is visible...
-
-            statusContainer.EnsureVisible( statusContainer.Items.Count - 1 );
-
-            statusContainer.Refresh();
+            GAVPI.Log.Entry( LogMessage );
 
         }  //  private void UpdateStatusLog( string )
 

--- a/GAVPI/GAVPI/frmGAVPI.Designer.cs
+++ b/GAVPI/GAVPI/frmGAVPI.Designer.cs
@@ -36,14 +36,14 @@
             this.loadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mainStripProfile = new System.Windows.Forms.ToolStripMenuItem();
+            this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mainStripSettings = new System.Windows.Forms.ToolStripMenuItem();
             this.mainStripAbout = new System.Windows.Forms.ToolStripMenuItem();
-            this.lstMainHearing = new System.Windows.Forms.ListView();
+            this.lstMainHearing = new System.Windows.Forms.ListBox();
             this.RecognizedColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.btnMainListen = new System.Windows.Forms.Button();
             this.btnMainStop = new System.Windows.Forms.Button();
-            this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mainStatStrip.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -61,7 +61,7 @@
             // btmStripStatus
             // 
             this.btmStripStatus.Name = "btmStripStatus";
-            this.btmStripStatus.Size = new System.Drawing.Size(75, 17);
+            this.btmStripStatus.Size = new System.Drawing.Size(92, 17);
             this.btmStripStatus.Text = "NOT LISTENING";
             // 
             // menuStrip1
@@ -83,20 +83,20 @@
             this.loadToolStripMenuItem,
             this.exitToolStripMenuItem});
             this.mainStripFile.Name = "mainStripFile";
-            this.mainStripFile.Size = new System.Drawing.Size(36, 20);
+            this.mainStripFile.Size = new System.Drawing.Size(37, 20);
             this.mainStripFile.Text = "File";
             // 
             // loadToolStripMenuItem
             // 
             this.loadToolStripMenuItem.Name = "loadToolStripMenuItem";
-            this.loadToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.loadToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
             this.loadToolStripMenuItem.Text = "Open Profile";
             this.loadToolStripMenuItem.Click += new System.EventHandler(this.loadToolStripMenuItem_Click);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(140, 22);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -106,27 +106,34 @@
             this.newToolStripMenuItem,
             this.editToolStripMenuItem});
             this.mainStripProfile.Name = "mainStripProfile";
-            this.mainStripProfile.Size = new System.Drawing.Size(50, 20);
+            this.mainStripProfile.Size = new System.Drawing.Size(53, 20);
             this.mainStripProfile.Text = "Profile";
+            // 
+            // newToolStripMenuItem
+            // 
+            this.newToolStripMenuItem.Name = "newToolStripMenuItem";
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(112, 22);
+            this.newToolStripMenuItem.Text = "New";
+            this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
             // 
             // editToolStripMenuItem
             // 
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(112, 22);
             this.editToolStripMenuItem.Text = "Modify";
             this.editToolStripMenuItem.Click += new System.EventHandler(this.modifyToolStripMenuItem_Click);
             // 
             // mainStripSettings
             // 
             this.mainStripSettings.Name = "mainStripSettings";
-            this.mainStripSettings.Size = new System.Drawing.Size(55, 20);
+            this.mainStripSettings.Size = new System.Drawing.Size(61, 20);
             this.mainStripSettings.Text = "Settings";
             this.mainStripSettings.Click += new System.EventHandler(this.mainStripSettings_Click);
             // 
             // mainStripAbout
             // 
             this.mainStripAbout.Name = "mainStripAbout";
-            this.mainStripAbout.Size = new System.Drawing.Size(47, 20);
+            this.mainStripAbout.Size = new System.Drawing.Size(52, 20);
             this.mainStripAbout.Text = "About";
             this.mainStripAbout.Click += new System.EventHandler(this.mainStripAbout_Click);
             // 
@@ -135,15 +142,10 @@
             this.lstMainHearing.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.lstMainHearing.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.RecognizedColumn});
-            this.lstMainHearing.GridLines = true;
             this.lstMainHearing.Location = new System.Drawing.Point(12, 27);
             this.lstMainHearing.Name = "lstMainHearing";
-            this.lstMainHearing.Size = new System.Drawing.Size(545, 180);
-            this.lstMainHearing.TabIndex = 2;
-            this.lstMainHearing.UseCompatibleStateImageBehavior = false;
-            this.lstMainHearing.View = System.Windows.Forms.View.Details;
+            this.lstMainHearing.Size = new System.Drawing.Size(545, 173);
+             this.lstMainHearing.TabIndex = 2;
             // 
             // RecognizedColumn
             // 
@@ -173,13 +175,6 @@
             this.btnMainStop.UseVisualStyleBackColor = true;
             this.btnMainStop.Click += new System.EventHandler(this.btnMainStop_Click);
             // 
-            // newToolStripMenuItem
-            // 
-            this.newToolStripMenuItem.Name = "newToolStripMenuItem";
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.newToolStripMenuItem.Text = "New";
-            this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
-            // 
             // frmGAVPI
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -198,7 +193,7 @@
             this.Name = "frmGAVPI";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "GAVPI : Graphical AVPI";
-            this.Activated += new System.EventHandler( frmGAVPI_Activated );
+            this.Activated += new System.EventHandler(this.frmGAVPI_Activated);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmGAVPI_FormClosing);
             this.mainStatStrip.ResumeLayout(false);
             this.mainStatStrip.PerformLayout();
@@ -220,7 +215,7 @@
         private System.Windows.Forms.ToolStripMenuItem mainStripAbout;
         private System.Windows.Forms.ToolStripMenuItem mainStripProfile;
         private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
-        private System.Windows.Forms.ListView lstMainHearing;
+        private System.Windows.Forms.ListBox lstMainHearing;
         private System.Windows.Forms.Button btnMainListen;
         private System.Windows.Forms.Button btnMainStop;
         private System.Windows.Forms.ColumnHeader RecognizedColumn;

--- a/GAVPI/GAVPI/frmGAVPI.cs
+++ b/GAVPI/GAVPI/frmGAVPI.cs
@@ -35,7 +35,7 @@ namespace GAVPI
 
         private void frmGAVPI_Activated( object sender, System.EventArgs e )
         {
-
+            
             //  If a Profile isn't loaded, disable Profile->Modify and the Listen button.
 
             if( GAVPI.vi_profile.IsEmpty() ) {
@@ -44,6 +44,11 @@ namespace GAVPI
                 editToolStripMenuItem.Enabled = false;
 
             }  //  if()
+
+            //  Ensure the log is updated to reflect any additional entries and move to the last log item...
+
+            lstMainHearing.DataSource = GAVPI.Log.ToArray();
+            lstMainHearing.TopIndex = GAVPI.Log.Count() - 1;
 
         }  //  private void frmGAVPI_Activated( object, System.EventArgs )
 
@@ -138,9 +143,7 @@ namespace GAVPI
             //  Refer to our general Profile editing handler...
 
             modifyToolStripMenuItem_Click( sender, e );
-
-           // GAVPI.OpenProfileEditor();
-            
+                        
         }
 
         // Modify Existing
@@ -196,7 +199,7 @@ namespace GAVPI
         private void btnMainListen_Click(object sender, EventArgs e)
         {
 		
-			if( GAVPI.vi.load_listen( lstMainHearing ) ) {
+			if( GAVPI.vi.load_listen() ) {
 				
 				//
 				//  We have successfully instantiated the speech recognition engine and we are ready to accept user
@@ -266,6 +269,11 @@ namespace GAVPI
             //  Refresh the UI...
 
             btmStripStatus.Text = Status;
+       
+            //  Ensure the log is updated to reflect any additional entries and move to the last log item...
+
+            lstMainHearing.DataSource = GAVPI.Log.ToArray();
+            lstMainHearing.TopIndex = GAVPI.Log.Count() - 1;
 
         }  //  public void RefreshUI()
 

--- a/GAVPI/GAVPI/frmProfile.Designer.cs
+++ b/GAVPI/GAVPI/frmProfile.Designer.cs
@@ -605,7 +605,7 @@
             this.MainMenuStrip = this.menuProfile;
             this.MinimumSize = new System.Drawing.Size(729, 291);
             this.Name = "frmProfile";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Profile";
             this.Load += new System.EventHandler(this.frmProfile_Load);
             this.menuProfile.ResumeLayout(false);


### PR DESCRIPTION
Implemented a trivial, thread-safe logging class: Logging.cs.

Instaniated Logging as GAVPI.Log, with a callback to GAVPI.OnLogMessage() when a log entry is made.

Implement GAVPI.CloseProfileEditor() to complement GAVPI.OpenProfileEditor().

Implement GAVPI.NotifyUnsavedChanges() to prompt a user to save an edited Profile if it remains unsaved.  (Typically used prior to Profile-destructive actions, removing same functionality from VI.cs.)

Simplified GAVPI.NewProfile().

Removed the dependancy on a ListView as a status container in VI.cs, modifying VI.load_listen() to accept no parameters and redirecting VI.UpdateStatusLog() to the GAVPI.Log object.

Replaced the ListView control in frmGAVPI.Designer.cs with a ListBox (for the time being, at least).  A ListBox can easily be bound to a DataSource - provided by a call to Logging.ToArray().

Updated frmGAVPI.frmGAVPI_Activated() and frmGAVPI.RefreshUI() to source the content of the log ListBox from GAVPI.Log.

I think that's it.