### PR TITLE
Completed auto-load, auto-listen functionality.

### DIFF
--- a/GAVPI/GAVPI/GAVPI.cs
+++ b/GAVPI/GAVPI/GAVPI.cs
@@ -322,6 +322,10 @@ namespace GAVPI
             string ProfilePath = new Uri( System.IO.Path.GetDirectoryName( 
                 System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase ) ).LocalPath + "\\Profiles";
             
+            //  If there isn't a Profiles directory within the directory GAVPI was launched from, go no further.
+
+            if( !Directory.Exists( ProfilePath ) ) return;
+
             XmlDocument Profile = new XmlDocument();
            
             //  Enumerate the XML Profiles within the sub-folder, extracting the filename of a user-chosen
@@ -747,7 +751,16 @@ namespace GAVPI
 
                 profile_dialog.Title = "Select a Profile to open";
                 profile_dialog.Filter = "Profiles (*.XML)|*.XML|All Files (*.*)|*.*";
-                profile_dialog.RestoreDirectory = true;
+
+                //  Try get the path to a directory within GAVPI's own directory called "Profiles", and make that
+                //  the default directory in the OpenFileDialog.
+
+                string GAVPIPath = new Uri( System.IO.Path.GetDirectoryName( 
+                    System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase ) ).LocalPath;
+
+                if( Directory.Exists( GAVPIPath + "\\Profiles" ) ) GAVPIPath += "\\Profiles";
+
+                profile_dialog.InitialDirectory = GAVPIPath;
 
                 if ( profile_dialog.ShowDialog() == DialogResult.Cancel ) return false;
 

--- a/GAVPI/GAVPI/VI_Profile.cs
+++ b/GAVPI/GAVPI/VI_Profile.cs
@@ -332,9 +332,13 @@ namespace GAVPI
                 writer.WriteStartDocument();
                 writer.WriteStartElement("gavpi");
 
-                writer.WriteStartElement( "AssociatedProcess" );
-                writer.WriteString( AssociatedProcess );
-                writer.WriteEndElement();
+                if( AssociatedProcess != null ) {
+
+                    writer.WriteStartElement( "AssociatedProcess" );
+                    writer.WriteString( AssociatedProcess );
+                    writer.WriteEndElement();
+
+                }  //  if()
 
                 foreach (VI_Action_Sequence ack_seq in Profile_ActionSequences)
                 {

--- a/GAVPI/GAVPI/frmProfile.Designer.cs
+++ b/GAVPI/GAVPI/frmProfile.Designer.cs
@@ -571,7 +571,7 @@
             this.AssociatedProcessTextBox.Name = "AssociatedProcessTextBox";
             this.AssociatedProcessTextBox.Size = new System.Drawing.Size(683, 20);
             this.AssociatedProcessTextBox.TabIndex = 5;
-            this.AssociatedProcessTextBox.TextChanged += new System.EventHandler(this.AssociatedProcessTextBox_TextChanged);
+            this.AssociatedProcessTextBox.TextChanged += new System.EventHandler( this.AssociatedProcessTextBox_TextChanged );
             // 
             // AssociatedProcessLabel
             // 

--- a/GAVPI/GAVPI/frmProfile.cs
+++ b/GAVPI/GAVPI/frmProfile.cs
@@ -555,18 +555,15 @@ namespace GAVPI
             btmStatusProfile.Text = GAVPI.GetStatusString();
 
 		}  //  private void ProfileEdited()
-
         
-
-
-        
-
 
 
         //
         //  private void AssociatedProcessButton_Click( object, EventArgs )
         //
-        //
+        //  Provide the opportunity for the user to select an external executable to associate with this Profile via
+        //  an OpenFileDialog.  Startup and termination of the executable may be monitored and the associated Profile
+        //  loaded automatically.
         //
 
         private void AssociatedProcessButton_Click( object sender, EventArgs e )
@@ -590,6 +587,10 @@ namespace GAVPI
             
                 AssociatedProcessTextBox.Text = dialog.FileName;
 
+                //  And refer to the text box event handler.
+
+                AssociatedProcessTextBox_TextChanged( sender, e );
+
             }  //  using()
 
         }  //  private void AssociatedProcessButton_Click( object, EventArgs )
@@ -597,26 +598,30 @@ namespace GAVPI
 
 
         //
+        //  private void AssociatedProcessTextBox_LostFocus( object, EventArgs )
         //
-        //
-        //
+        //  If the user manually edits the content of the associated process filename text box, acknowledge
+        //  those changes.
         //
 
         private void AssociatedProcessTextBox_TextChanged( object sender, EventArgs e )
         {
            
-            //  Assign the content of the TextBox to the Profile.
+            //  Assign the content of the TextBox to the Profile. CHECK TO MAKE SURE OLD ONE IS REMOVED!
+
+            if( GAVPI.vi_profile.GetAssociatedProcess() == AssociatedProcessTextBox.Text ) return;
 
             GAVPI.vi_profile.SetAssociatedProcess( AssociatedProcessTextBox.Text );
+            
+            //  Add to the process tracker (infers removal of a prior instance).
+
+            GAVPI.AddAutoOpenProfile( AssociatedProcessTextBox.Text, GAVPI.vi_profile.GetProfileFilename() );
 
             //  Consider this Profile edited.
 
-           // ProfileEdited();
+            ProfileEdited();
 
-        }
-
-        
-
+        }  //  private void AssociatedProcessTextBox_LostFocus( object, EventArgs )
 
     }
 

--- a/GAVPI/GAVPI/frmSettings.cs
+++ b/GAVPI/GAVPI/frmSettings.cs
@@ -69,6 +69,9 @@ namespace GAVPI
             cbSettingsSynthesizer.SelectedItem     = vi_settings.voice_info;
             cbSettingsPushToTalkMode.SelectedItem  = vi_settings.pushtotalk_mode;
             cbSettingsPushToTalkKey.SelectedItem   = vi_settings.pushtotalk_key;
+  
+            AutomaticallyListen.Enabled = AutoLoadProfiles.Checked ? true : false;
+
             // TODO
             // unhandled recording devices
             //cbSettingsRecordingDevice.SelectedItem =
@@ -94,16 +97,26 @@ namespace GAVPI
             this.Close();
         }
 
-        private void StartUpShowMainWindow_CheckedChanged( object sender, EventArgs e ) {
-
-
-        }
+        private void StartUpShowMainWindow_CheckedChanged( object sender, EventArgs e ) {}
 
         private void AutoLoadProfiles_CheckedChanged( object sender, EventArgs e )
         {
 
-            if( AutoLoadProfiles.Checked ) GAVPI.EnableAutoOpenProfile( sender, e );
-            else GAVPI.DisableAutoOpenProfile( sender, e );
+            if( AutoLoadProfiles.Checked ) {
+              
+                AutomaticallyListen.Enabled = true;
+                GAVPI.EnableAutoOpenProfile( sender, e );
+
+            } else {
+
+                AutomaticallyListen.Enabled = false;                
+                GAVPI.DisableAutoOpenProfile( sender, e );
+
+            }
+
+        }
+
+        private void AutomaticallyListen_CheckedChanged( object sender, EventArgs e ) {
 
         }
         


### PR DESCRIPTION
Auto-load/listen now works with associations made after GAVPI has started, via frmProfile "Associate With..." text box and button.  The settings regarding auto-load/listen are more user friendly, and - equally user friendlier - GAVPI.LoadProfile() attempts to set a "Profiles" folder in GAVPI's own folder as the file chooser dialog's default location.  