### PR TITLE
Call Application.Exit() on form close.

### DIFF
--- a/GAVPI/GAVPI/frmGAVPI.cs
+++ b/GAVPI/GAVPI/frmGAVPI.cs
@@ -52,7 +52,7 @@ namespace GAVPI
 
         private void frmGAVPI_FormClosing( object sender, FormClosingEventArgs e )
         {
-
+            Application.Exit();
 
         }  //  private void frmGAVPI_FormClosing
 


### PR DESCRIPTION
I noticed the application wasn't terminating when I closed the form so I've added application.Exit() to the handler. Eventually this will need to be handle more appropriately but for now this has been tested and works locally.