### PR TITLE
Use system defaults for voice, locale

### DIFF
--- a/GAVPI/GAVPI/Core/Engine/Settings.cs
+++ b/GAVPI/GAVPI/Core/Engine/Settings.cs
@@ -69,45 +69,50 @@ namespace GAVPI
                     + gavpi_settings.DocumentElement.Name);
                 }
                 XmlNodeList gavpi_settings_elements = gavpi_settings.DocumentElement.ChildNodes;
+            
                 foreach (XmlNode element in gavpi_settings_elements)
                 {
-                    if (element.Name == "Settings")
+                    if (element.NodeType != XmlNodeType.Comment)
                     {
 
-                        string xml_default_profile_name = element.Attributes.GetNamedItem("default_profile_name").Value;
-                        string xml_default_profile_filepath = element.Attributes.GetNamedItem("default_profile_filepath").Value;
-                        string xml_voice_info = element.Attributes.GetNamedItem("voice_info").Value;
-                        string xml_pushtotalk_mode = element.Attributes.GetNamedItem("pushtotalk_mode").Value;
-                        string xml_pushtotalk_key = element.Attributes.GetNamedItem("pushtotalk_key").Value;
-                        string xml_recognizer_info = element.Attributes.GetNamedItem("recognizer_info").Value;
+                        if (element.Name == "Settings")
+                        {
 
-                        // If any of these are not specified in settings, we can leave with defaults loaded in Settings constructor.
-                        // This lets us default to an individual's local system locale / available voices.
-                        if (!String.IsNullOrEmpty(xml_voice_info))
-                            voice_info = xml_voice_info;
+                            string xml_default_profile_name = element.Attributes.GetNamedItem("default_profile_name").Value;
+                            string xml_default_profile_filepath = element.Attributes.GetNamedItem("default_profile_filepath").Value;
+                            string xml_voice_info = element.Attributes.GetNamedItem("voice_info").Value;
+                            string xml_pushtotalk_mode = element.Attributes.GetNamedItem("pushtotalk_mode").Value;
+                            string xml_pushtotalk_key = element.Attributes.GetNamedItem("pushtotalk_key").Value;
+                            string xml_recognizer_info = element.Attributes.GetNamedItem("recognizer_info").Value;
 
-                        if (!String.IsNullOrEmpty(xml_default_profile_name))
-                            default_profile_name = xml_default_profile_name;
+                            // If any of these are not specified in settings, we can leave with defaults loaded in Settings constructor.
+                            // This lets us default to an individual's local system locale / available voices.
+                            if (!String.IsNullOrEmpty(xml_voice_info))
+                                voice_info = xml_voice_info;
 
-                        if (!String.IsNullOrEmpty(xml_default_profile_filepath))
-                            default_profile_filepath = xml_default_profile_filepath;
+                            if (!String.IsNullOrEmpty(xml_default_profile_name))
+                                default_profile_name = xml_default_profile_name;
 
-                        if (!String.IsNullOrEmpty(xml_pushtotalk_mode))
-                            pushtotalk_mode = xml_pushtotalk_mode;
+                            if (!String.IsNullOrEmpty(xml_default_profile_filepath))
+                                default_profile_filepath = xml_default_profile_filepath;
 
-                        if (!String.IsNullOrEmpty(xml_pushtotalk_key))
-                            pushtotalk_key = xml_pushtotalk_key;
+                            if (!String.IsNullOrEmpty(xml_pushtotalk_mode))
+                                pushtotalk_mode = xml_pushtotalk_mode;
 
-                        if (!String.IsNullOrEmpty(xml_voice_info))
-                            voice_info = xml_voice_info;
+                            if (!String.IsNullOrEmpty(xml_pushtotalk_key))
+                                pushtotalk_key = xml_pushtotalk_key;
 
-                        if (!String.IsNullOrEmpty(xml_recognizer_info))
-                            recognizer_info = new System.Globalization.CultureInfo(xml_recognizer_info);
-                        
-                    }
-                    else
-                    {
-                        throw new Exception("Malformed settings file, unexpected element: " + element.Name);
+                            if (!String.IsNullOrEmpty(xml_voice_info))
+                                voice_info = xml_voice_info;
+
+                            if (!String.IsNullOrEmpty(xml_recognizer_info))
+                                recognizer_info = new System.Globalization.CultureInfo(xml_recognizer_info);
+
+                        }
+                        else
+                        {
+                            throw new Exception("Malformed settings file, unexpected element: " + element.Name);
+                        }
                     }
                 }
             }

--- a/GAVPI/GAVPI/Core/Engine/Settings.cs
+++ b/GAVPI/GAVPI/Core/Engine/Settings.cs
@@ -73,33 +73,37 @@ namespace GAVPI
                 {
                     if (element.Name == "Settings")
                     {
-                        // Warning : can be null
+
                         string xml_default_profile_name = element.Attributes.GetNamedItem("default_profile_name").Value;
-                        // Warning : can be null
                         string xml_default_profile_filepath = element.Attributes.GetNamedItem("default_profile_filepath").Value;
-                        
                         string xml_voice_info = element.Attributes.GetNamedItem("voice_info").Value;
                         string xml_pushtotalk_mode = element.Attributes.GetNamedItem("pushtotalk_mode").Value;
                         string xml_pushtotalk_key = element.Attributes.GetNamedItem("pushtotalk_key").Value;
                         string xml_recognizer_info = element.Attributes.GetNamedItem("recognizer_info").Value;
 
-
-                        if (String.IsNullOrEmpty(xml_voice_info) &&
-                                String.IsNullOrEmpty(xml_pushtotalk_mode) &&
-                                String.IsNullOrEmpty(xml_pushtotalk_key) &&
-                                String.IsNullOrEmpty(xml_recognizer_info))
-                        {
-                            throw new Exception("Malformed settings file, some values are null.");
-                        }
-                        else
-                        {
-                            default_profile_name = xml_default_profile_name;
-                            default_profile_filepath = xml_default_profile_filepath;
+                        // If any of these are not specified in settings, we can leave with defaults loaded in Settings constructor.
+                        // This lets us default to an individual's local system locale / available voices.
+                        if (!String.IsNullOrEmpty(xml_voice_info))
                             voice_info = xml_voice_info;
+
+                        if (!String.IsNullOrEmpty(xml_default_profile_name))
+                            default_profile_name = xml_default_profile_name;
+
+                        if (!String.IsNullOrEmpty(xml_default_profile_filepath))
+                            default_profile_filepath = xml_default_profile_filepath;
+
+                        if (!String.IsNullOrEmpty(xml_pushtotalk_mode))
                             pushtotalk_mode = xml_pushtotalk_mode;
+
+                        if (!String.IsNullOrEmpty(xml_pushtotalk_key))
                             pushtotalk_key = xml_pushtotalk_key;
+
+                        if (!String.IsNullOrEmpty(xml_voice_info))
+                            voice_info = xml_voice_info;
+
+                        if (!String.IsNullOrEmpty(xml_recognizer_info))
                             recognizer_info = new System.Globalization.CultureInfo(xml_recognizer_info);
-                        }
+                        
                     }
                     else
                     {

--- a/GAVPI/GAVPI/Core/Engine/Settings.cs
+++ b/GAVPI/GAVPI/Core/Engine/Settings.cs
@@ -83,10 +83,11 @@ namespace GAVPI
                         string xml_pushtotalk_key = element.Attributes.GetNamedItem("pushtotalk_key").Value;
                         string xml_recognizer_info = element.Attributes.GetNamedItem("recognizer_info").Value;
 
-                     if (String.IsNullOrEmpty(xml_voice_info) &&
-                             String.IsNullOrEmpty(xml_pushtotalk_mode) &&
-                             String.IsNullOrEmpty(xml_pushtotalk_key) &&
-                             String.IsNullOrEmpty(xml_recognizer_info))
+
+                        if (String.IsNullOrEmpty(xml_voice_info) &&
+                                String.IsNullOrEmpty(xml_pushtotalk_mode) &&
+                                String.IsNullOrEmpty(xml_pushtotalk_key) &&
+                                String.IsNullOrEmpty(xml_recognizer_info))
                         {
                             throw new Exception("Malformed settings file, some values are null.");
                         }

--- a/GAVPI/GAVPI/GAVPI.csproj
+++ b/GAVPI/GAVPI/GAVPI.csproj
@@ -268,6 +268,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Icons\gavpi-listening.ico" />
+    <Content Include="gavpi-settings.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Icons\gavpi.ico" />
   </ItemGroup>
   <ItemGroup>

--- a/GAVPI/GAVPI/gavpi-settings.xml
+++ b/GAVPI/GAVPI/gavpi-settings.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<gavpi>
+  <!-- Empty strings mean use system defaults -->
+  <Settings default_profile_name="" default_profile_filepath="" voice_info="" recognizer_info="" pushtotalk_mode="Off" pushtotalk_key="Scroll"  />
+</gavpi>


### PR DESCRIPTION
Fixes issue #75 . 

Previously there was a default settings file with "en_US" locale and "Microsoft Anna" voice. On UK PCs, this voice is typically not available. Now empty/undefined settings let you revert to whatever is available on the system.

I've added a new settings file for the release, couldn't find one in the repo already.